### PR TITLE
uppercase data key

### DIFF
--- a/service/mail/aws/sender.go
+++ b/service/mail/aws/sender.go
@@ -71,7 +71,7 @@ type awsApiSender struct {
 const addressTpl = `"%s" <%s>`
 
 func (a *awsApiSender) Send(notify *service.Notification) (string, error) {
-	dataJson, err := json.Marshal(notify.Data)
+	dataJson, err := json.Marshal(notify.UpperKeyData())
 	if err != nil {
 		return "", errors.New("failed to marshal data")
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"strings"
 )
 
 type Notification struct {
@@ -10,6 +11,14 @@ type Notification struct {
 	Data   map[string]string
 	From   *Info
 	SendTo []*Info
+}
+
+func (n *Notification) UpperKeyData() map[string]string {
+	result := map[string]string{}
+	for k, v := range n.Data {
+		result[strings.ToUpper(k)] = v
+	}
+	return result
 }
 
 func (n *Notification) GetTemplateName() string {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -105,3 +105,46 @@ func TestGetTemplateName2(t *testing.T) {
 		})
 	}
 }
+
+func TestUpperKeyData(t *testing.T) {
+	tests := []struct {
+		name     string
+		n        *Notification
+		expected map[string]string
+	}{
+		{
+			name: "empty data",
+			n: &Notification{
+				Data: map[string]string{},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name: "non-empty data",
+			n: &Notification{
+				Data: map[string]string{
+					"key1_aaa": "value1",
+					"key2":     "value2",
+				},
+			},
+			expected: map[string]string{
+				"KEY1_AAA": "value1",
+				"KEY2":     "value2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.n.UpperKeyData()
+			if len(actual) != len(tt.expected) {
+				t.Errorf("UpperKeyData() = %v, want %v", actual, tt.expected)
+			}
+			for k, v := range actual {
+				if v != tt.expected[k] {
+					t.Errorf("UpperKeyData() = %v, want %v", actual, tt.expected)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
when create aws mail, all the data key will transfer to uppercase string